### PR TITLE
Update nginx config template to have resolver

### DIFF
--- a/ingress/nginx.tpl
+++ b/ingress/nginx.tpl
@@ -41,6 +41,7 @@ http {
         server_name {{ service.Spec.Labels['ingress.host'] }};
 
         location / {
+            resolver 127.0.0.11;
             set $service_host {{ service.Spec.Name }};
             set $service_port {{ service.Spec.Labels['ingress.port']|default('80') }};
             set $service_path {{ service.Spec.Labels['ingress.path']|default('/') }};


### PR DESCRIPTION
Hello. I've tried to use your image to route traffic between my nodes, but encountered strange problem.

```
2017/11/14 10:25:24 [error] 163#163: *54 no resolver defined to resolve my-service, client: 10.255.0.2, server: my-service.company.tld, request: "GET / HTTP/1.1", host: "my-service.company.tld"
```

I've searched for possible solution and adding resolver to config worked. I'm not sure it's best possible option, but it worked for me.